### PR TITLE
Convert transaction manager to event store plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "prooph/event-store" : "6.0-beta.1",
+        "prooph/event-store" : "dev-develop",
         "prooph/service-bus" : "^4.0"
     },
     "require-dev": {

--- a/docs/transaction_manager.md
+++ b/docs/transaction_manager.md
@@ -2,10 +2,12 @@
 
 ## Set Up
 To enable transaction handling based on command dispatch you need to set up the [TransactionManager](src/TransactionManager.php).
-The only dependency of the transaction manager is an instance of `Prooph\EventStore\EventStore`.
+The transaction manager acts as command bus AND event store plugin so you need to attach it to both:
 
-Then simply add the transaction manger as a plugin to the `command bus`:
 ```php
+/** @var $eventStore Prooph\EventStore\EventStore */
+$transactionManager->setUp($eventStore);
+
 /** @var $commandBus Prooph\ServiceBus\CommandBus */
 $commandBus->utilize($transactionManager);
 ```
@@ -14,9 +16,9 @@ That's it!
 
 ### Container-Driven Set Up
 If you are using the `container-aware factories` shipped with prooph/service-bus you may also
-want to auto register the `TransactionManager`. As long as the event store is available as service `Prooph\EventStore\EventStore` in the container you can use
+want to auto register the `TransactionManager`. As long as the command bus is available as service `Prooph\ServiceBus\CommandBus` in the container you can use
 the [TransactionManagerFactory](src/Container/TransactionManagerFactory.php) for that. Just map the factory to a service name like `prooph.transaction_manager` and
-add the service name to the plugin list of the command bus configuration. Please refer to [prooph/service-bus docs](https://github.com/prooph/service-bus/blob/master/docs/factories.md)
+add the service name to the plugin list of the event store configuration. Please refer to [prooph/event-store docs](https://github.com/prooph/event-store/blob/master/docs/interop_factories.md#event-store-factory)
 for more details.
 
 ## Features

--- a/src/Container/TransactionManagerFactory.php
+++ b/src/Container/TransactionManagerFactory.php
@@ -11,7 +11,6 @@
 namespace Prooph\EventStoreBusBridge\Container;
 
 use Interop\Container\ContainerInterface;
-use Prooph\EventStore\EventStore;
 use Prooph\EventStoreBusBridge\TransactionManager;
 use Prooph\ServiceBus\CommandBus;
 

--- a/src/Container/TransactionManagerFactory.php
+++ b/src/Container/TransactionManagerFactory.php
@@ -13,6 +13,7 @@ namespace Prooph\EventStoreBusBridge\Container;
 use Interop\Container\ContainerInterface;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStoreBusBridge\TransactionManager;
+use Prooph\ServiceBus\CommandBus;
 
 /**
  * Class TransactionManagerFactory
@@ -23,7 +24,12 @@ final class TransactionManagerFactory
 {
     public function __invoke(ContainerInterface $container)
     {
-        $eventStore = $container->get(EventStore::class);
-        return new TransactionManager($eventStore);
+        $commandBus = $container->get(CommandBus::class);
+
+        $transactionManager = new TransactionManager();
+
+        $commandBus->utilize($transactionManager);
+
+        return $transactionManager;
     }
 }

--- a/src/TransactionManager.php
+++ b/src/TransactionManager.php
@@ -19,6 +19,7 @@ use Prooph\Common\Event\DetachAggregateHandlers;
 use Prooph\Common\Messaging\Command;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Plugin\Plugin;
 use Prooph\EventStore\Stream\Stream;
 use Prooph\ServiceBus\CommandBus;
 
@@ -32,7 +33,7 @@ use Prooph\ServiceBus\CommandBus;
  *
  * @package Prooph\EventStoreBusBridge
  */
-final class TransactionManager implements ActionEventListenerAggregate
+final class TransactionManager implements Plugin, ActionEventListenerAggregate
 {
     use DetachAggregateHandlers;
 
@@ -48,8 +49,9 @@ final class TransactionManager implements ActionEventListenerAggregate
 
     /**
      * @param EventStore $eventStore
+     * @return void
      */
-    public function __construct(EventStore $eventStore)
+    public function setUp(EventStore $eventStore)
     {
         $this->eventStore = $eventStore;
         $this->eventStore->getActionEventEmitter()->attachListener('create.pre', [$this, 'onEventStoreCreateStream'], -1000);

--- a/tests/Container/TransactionManagerFactoryTest.php
+++ b/tests/Container/TransactionManagerFactoryTest.php
@@ -11,8 +11,6 @@
 namespace ProophTest\EventStoreBusBridge\Container;
 
 use Interop\Container\ContainerInterface;
-use Prooph\Common\Event\ActionEventEmitter;
-use Prooph\EventStore\EventStore;
 use Prooph\EventStoreBusBridge\Container\TransactionManagerFactory;
 use Prooph\EventStoreBusBridge\TransactionManager;
 use Prooph\ServiceBus\CommandBus;

--- a/tests/Container/TransactionManagerFactoryTest.php
+++ b/tests/Container/TransactionManagerFactoryTest.php
@@ -15,6 +15,8 @@ use Prooph\Common\Event\ActionEventEmitter;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStoreBusBridge\Container\TransactionManagerFactory;
 use Prooph\EventStoreBusBridge\TransactionManager;
+use Prooph\ServiceBus\CommandBus;
+use Prophecy\Argument;
 
 /**
  * Class TransactionManagerFactoryTest
@@ -28,14 +30,13 @@ final class TransactionManagerFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function it_creates_a_transaction_manager()
     {
-        $actionEventEmitter = $this->prophesize(ActionEventEmitter::class);
-        $eventStore = $this->prophesize(EventStore::class);
+        $commandBus = $this->prophesize(CommandBus::class);
 
-        $eventStore->getActionEventEmitter()->willReturn($actionEventEmitter->reveal());
+        $commandBus->utilize(Argument::type(TransactionManager::class))->shouldBeCalled();
 
         $container = $this->prophesize(ContainerInterface::class);
 
-        $container->get(EventStore::class)->willReturn($eventStore->reveal());
+        $container->get(CommandBus::class)->willReturn($commandBus->reveal());
 
         $factory = new TransactionManagerFactory();
 

--- a/tests/TransactionManagerTest.php
+++ b/tests/TransactionManagerTest.php
@@ -55,7 +55,9 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
 
         $eventStoreMock->getActionEventEmitter()->willReturn($emitter->reveal());
 
-        $transactionManager = new TransactionManager($eventStoreMock->reveal());
+        $transactionManager = new TransactionManager();
+
+        $transactionManager->setUp($eventStoreMock->reveal());
 
         $this->assertEquals([$transactionManager, 'onEventStoreCreateStream'], $createStreamListener);
         $this->assertEquals([$transactionManager, 'onEventStoreAppendToStream'], $appendToStreamListener);
@@ -66,7 +68,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function it_attaches_itself_to_command_bus_initialize_and_finalize_events()
     {
-        $transactionManager = new TransactionManager($this->getEventStoreObjectProphecy()->reveal());
+        $transactionManager = new TransactionManager();
 
         $commandBusEmitter = $this->prophesize(ActionEventEmitter::class);
 
@@ -87,7 +89,9 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
 
         $eventStoreMock->beginTransaction()->shouldBeCalled();
 
-        $transactionManager = new TransactionManager($eventStoreMock->reveal());
+        $transactionManager = new TransactionManager();
+
+        $transactionManager->setUp($eventStoreMock->reveal());
 
         $actionEvent = $this->prophesize(ActionEvent::class);
 
@@ -107,7 +111,9 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
 
         $eventStoreMock->commit()->shouldBeCalled();
 
-        $transactionManager = new TransactionManager($eventStoreMock->reveal());
+        $transactionManager = new TransactionManager();
+
+        $transactionManager->setUp($eventStoreMock->reveal());
 
         $actionEvent = $this->prophesize(ActionEvent::class);
 
@@ -127,7 +133,9 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
 
         $eventStoreMock->rollback()->shouldBeCalled();
 
-        $transactionManager = new TransactionManager($eventStoreMock->reveal());
+        $transactionManager = new TransactionManager();
+
+        $transactionManager->setUp($eventStoreMock->reveal());
 
         $actionEvent = $this->prophesize(ActionEvent::class);
 
@@ -149,7 +157,9 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
 
         $eventStoreMock->rollback()->shouldNotBeCalled();
 
-        $transactionManager = new TransactionManager($eventStoreMock->reveal());
+        $transactionManager = new TransactionManager();
+
+        $transactionManager->setUp($eventStoreMock->reveal());
 
         $actionEvent = $this->prophesize(ActionEvent::class);
 
@@ -181,7 +191,9 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
 
         $eventStoreMock->beginTransaction()->shouldBeCalled();
 
-        $transactionManager = new TransactionManager($eventStoreMock->reveal());
+        $transactionManager = new TransactionManager();
+
+        $transactionManager->setUp($eventStoreMock->reveal());
 
         //Now the command is set as currentCommand internally and later used when new stream is going to be created
         $transactionManager->onInitialize($initializeActionEvent->reveal());
@@ -237,7 +249,9 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
 
         $eventStoreMock->beginTransaction()->shouldBeCalled();
 
-        $transactionManager = new TransactionManager($eventStoreMock->reveal());
+        $transactionManager = new TransactionManager();
+
+        $transactionManager->setUp($eventStoreMock->reveal());
 
         //Now the command is set as currentCommand internally and later used when new stream is going to be created
         $transactionManager->onInitialize($initializeActionEvent->reveal());
@@ -281,7 +295,9 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
 
         $eventStoreMock = $this->getEventStoreObjectProphecy();
 
-        $transactionManager = new TransactionManager($eventStoreMock->reveal());
+        $transactionManager = new TransactionManager();
+
+        $transactionManager->setUp($eventStoreMock->reveal());
 
         $this->assertNull($transactionManager->onEventStoreCreateStream($createStreamActionEvent->reveal()));
     }
@@ -302,7 +318,9 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
 
         $eventStoreMock->beginTransaction()->shouldBeCalled();
 
-        $transactionManager = new TransactionManager($eventStoreMock->reveal());
+        $transactionManager = new TransactionManager();
+
+        $transactionManager->setUp($eventStoreMock->reveal());
 
         $transactionManager->onInitialize($initializeActionEvent->reveal());
 


### PR DESCRIPTION
This PR enables the usage of the transaction manager as event store plugin instead of requiring the event store in the constructor of the transaction manager. Also the transaction manager factory is aligned so that the event store is no longer pulled from the container.
Main reason for the change was a circular dependency problem when the transaction manager is used together with the snapshot plugin. 
For the record the old dependency chain compared with the new one:

CommandBus -> TransactionManager -> EventStore -> SnapshotPlugin **<- (circular dep)** CommandBus

new deps starting from event store as both plugins are event store plugins now:

CommandBus <- SnapshotPlugin <- **EventStore** -> TransactionManager -> CommandBus
