### PR TITLE
Support for PHP 7.1

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,0 +1,8 @@
+/**
+ * This file is part of the prooph/event-store-bus-bridge.
+ * (c) 2014-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2015-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: php
 
-php:
-  - 5.5
-  - 5.6
-  - 7
-
-env:
-  matrix:
-    - DEPENDENCIES=""
-    - DEPENDENCIES="--prefer-lowest --prefer-stable"
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.1
+      env:
+        - DEPENDENCIES=""
+        - TEST_COVERAGE=true
+    - php: 7.1
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
 
 before_script:
   - composer self-update
@@ -17,9 +18,10 @@ before_script:
 script:
   - php ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml
   - ./vendor/bin/php-cs-fixer fix -v --diff --dry-run
+  - ./vendor/bin/docheader check config/ examples/ src/ tests/
 
 after_success:
-  - php vendor/bin/coveralls -v
+  - if [[ $TEST_COVERAGE == 'true' ]]; then php vendor/bin/coveralls -v; fi
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - php ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml
   - ./vendor/bin/php-cs-fixer fix -v --diff --dry-run
 
-after_script:
+after_success:
   - php vendor/bin/coveralls -v
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,14 @@ php:
   - 5.6
   - 7
 
+env:
+  matrix:
+    - DEPENDENCIES=""
+    - DEPENDENCIES="--prefer-lowest --prefer-stable"
+
 before_script:
   - composer self-update
-  - composer update
+  - composer update --prefer-dist $DEPENDENCIES
 
 script:
   - php ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,15 @@
         "prooph"
     ],
     "require": {
-        "php": "~5.5|~7.0",
-        "prooph/event-store" : "^6.0",
-        "prooph/service-bus" : "^5.0"
+        "php": "^7.1",
+        "prooph/event-store" : "dev-php_7_1 as 7.0.0",
+        "prooph/service-bus" : "dev-php_7_1 as 6.0.0"
     },
     "require-dev": {
         "container-interop/container-interop": "^1.1",
-        "phpunit/phpunit": "~4.8",
-        "friendsofphp/php-cs-fixer": "^1.11.5",
+        "phpunit/phpunit": "^5.6",
+        "phpunit/phpunit-mock-objects": "^3.3.1",
+        "friendsofphp/php-cs-fixer": "^1.12.2",
         "satooshi/php-coveralls": "^1.0",
         "tobiju/bookdown-bootswatch-templates": "^0.2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,15 @@
     ],
     "require": {
         "php": "^7.1",
-        "prooph/event-store" : "dev-php_7_1 as 7.0.0",
-        "prooph/service-bus" : "dev-php_7_1 as 6.0.0"
+        "prooph/common" : "dev-php_7_1 as 4.0.0",
+        "prooph/service-bus" : "dev-php_7_1 as 6.0.0",
+        "prooph/event-store" : "dev-php_7_1 as 7.0.0"
     },
     "require-dev": {
         "container-interop/container-interop": "^1.1",
         "phpunit/phpunit": "^5.6",
         "phpunit/phpunit-mock-objects": "^3.3.1",
+        "phpspec/prophecy": "dev-patch-1 as 1.6.1",
         "friendsofphp/php-cs-fixer": "^1.12.2",
         "satooshi/php-coveralls": "^1.0",
         "tobiju/bookdown-bootswatch-templates": "^0.2.0"
@@ -42,5 +44,11 @@
         "psr-4": {
             "ProophTest\\EventStoreBusBridge\\": "tests/"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/prolic/prophecy.git"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "phpspec/prophecy": "dev-patch-1 as 1.6.1",
         "friendsofphp/php-cs-fixer": "^1.12.2",
         "satooshi/php-coveralls": "^1.0",
-        "tobiju/bookdown-bootswatch-templates": "^0.2.0"
+        "tobiju/bookdown-bootswatch-templates": "^0.2.0",
+        "malukenho/docheader": "^0.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     "require-dev": {
         "container-interop/container-interop": "^1.1",
         "phpunit/phpunit": "~4.8",
-        "fabpot/php-cs-fixer": "1.7.*",
-        "satooshi/php-coveralls": "dev-master",
+        "friendsofphp/php-cs-fixer": "^1.11.5",
+        "satooshi/php-coveralls": "^1.0",
         "tobiju/bookdown-bootswatch-templates": "^0.2.0"
     },
     "autoload": {

--- a/src/Container/EventPublisherFactory.php
+++ b/src/Container/EventPublisherFactory.php
@@ -7,6 +7,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
+
 namespace Prooph\EventStoreBusBridge\Container;
 
 use Interop\Container\ContainerInterface;

--- a/src/Container/EventPublisherFactory.php
+++ b/src/Container/EventPublisherFactory.php
@@ -1,12 +1,11 @@
 <?php
-/*
- * This file is part of the prooph/event-store-bus-bridge.
- * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2015-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * Date: 8/30/15 - 6:16 PM
  */
 namespace Prooph\EventStoreBusBridge\Container;
 

--- a/src/Container/TransactionManagerFactory.php
+++ b/src/Container/TransactionManagerFactory.php
@@ -51,7 +51,7 @@ final class TransactionManagerFactory
     {
         $this->commandBusServiceName = $commandBusServiceName;
     }
-    
+
     public function __invoke(ContainerInterface $container): TransactionManager
     {
         $commandBus = $container->get($this->commandBusServiceName);

--- a/src/Container/TransactionManagerFactory.php
+++ b/src/Container/TransactionManagerFactory.php
@@ -1,12 +1,11 @@
 <?php
-/*
- * This file is part of the prooph/event-store-bus-bridge.
- * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2015-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * Date: 8/30/15 - 2:14 PM
  */
 namespace Prooph\EventStoreBusBridge\Container;
 

--- a/src/Container/TransactionManagerFactory.php
+++ b/src/Container/TransactionManagerFactory.php
@@ -15,16 +15,46 @@ use Interop\Container\ContainerInterface;
 use Prooph\EventStoreBusBridge\TransactionManager;
 use Prooph\ServiceBus\CommandBus;
 
-/**
- * Class TransactionManagerFactory
- *
- * @package Prooph\EventStoreBusBridge\Container
- */
 final class TransactionManagerFactory
 {
-    public function __invoke(ContainerInterface $container)
+    /**
+     * @var string
+     */
+    private $commandBusServiceName;
+
+    /**
+     * Creates a new instance from a specified config, specifically meant to be used as static factory.
+     *
+     * In case you want to use another config key than provided by the factories, you can add the following factory to
+     * your config:
+     *
+     * <code>
+     * <?php
+     * return [
+     *     TransactionManager::class => [TransactionManagerFactory::class, 'command_bus_service_name'],
+     * ];
+     * </code>
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function __callStatic(string $name, array $arguments): TransactionManager
     {
-        $commandBus = $container->get(CommandBus::class);
+        if (! isset($arguments[0]) || ! $arguments[0] instanceof ContainerInterface) {
+            throw new \InvalidArgumentException(
+                sprintf('The first argument must be of type %s', ContainerInterface::class)
+            );
+        }
+        return (new static($name))->__invoke($arguments[0]);
+    }
+
+    public function __construct(string $commandBusServiceName = CommandBus::class)
+    {
+        $this->commandBusServiceName = $commandBusServiceName;
+    }
+    
+    public function __invoke(ContainerInterface $container): TransactionManager
+    {
+        $commandBus = $container->get($this->commandBusServiceName);
 
         $transactionManager = new TransactionManager();
 

--- a/src/Container/TransactionManagerFactory.php
+++ b/src/Container/TransactionManagerFactory.php
@@ -7,6 +7,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Prooph\EventStoreBusBridge\Container;
 
 use Interop\Container\ContainerInterface;

--- a/src/EventPublisher.php
+++ b/src/EventPublisher.php
@@ -32,29 +32,17 @@ final class EventPublisher implements Plugin
      */
     private $eventBus;
 
-    /**
-     * @param \Prooph\ServiceBus\EventBus $eventBus
-     */
     public function __construct(EventBus $eventBus)
     {
         $this->eventBus = $eventBus;
     }
 
-    /**
-     * @param EventStore $eventStore
-     * @return void
-     */
-    public function setUp(EventStore $eventStore)
+    public function setUp(EventStore $eventStore): void
     {
         $eventStore->getActionEventEmitter()->attachListener('commit.post', [$this, 'onEventStoreCommitPost']);
     }
 
-    /**
-     * Publish recorded events on the event bus
-     *
-     * @param ActionEvent $actionEvent
-     */
-    public function onEventStoreCommitPost(ActionEvent $actionEvent)
+    public function onEventStoreCommitPost(ActionEvent $actionEvent): void
     {
         $recordedEvents = $actionEvent->getParam('recordedEvents', new \ArrayIterator());
 

--- a/src/EventPublisher.php
+++ b/src/EventPublisher.php
@@ -1,12 +1,11 @@
 <?php
-/*
- * This file is part of the prooph/event-store-bus-bridge.
- * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2015-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * Date: 8/30/15 - 5:46 PM
  */
 namespace Prooph\EventStoreBusBridge;
 

--- a/src/EventPublisher.php
+++ b/src/EventPublisher.php
@@ -7,6 +7,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
+
 namespace Prooph\EventStoreBusBridge;
 
 use Prooph\Common\Event\ActionEvent;

--- a/src/EventPublisher.php
+++ b/src/EventPublisher.php
@@ -54,7 +54,7 @@ final class EventPublisher implements Plugin
      */
     public function onEventStoreCommitPost(ActionEvent $actionEvent)
     {
-        $recordedEvents = $actionEvent->getParam('recordedEvents', []);
+        $recordedEvents = $actionEvent->getParam('recordedEvents', new \ArrayIterator());
 
         foreach ($recordedEvents as $recordedEvent) {
             $this->eventBus->dispatch($recordedEvent);

--- a/src/TransactionManager.php
+++ b/src/TransactionManager.php
@@ -71,7 +71,7 @@ final class TransactionManager implements Plugin, ActionEventListenerAggregate
      */
     private function handleRecordedEvents(Iterator $recordedEvents): Iterator
     {
-        if (null !== $this->currentCommand || ! $this->currentCommand instanceof Message) {
+        if (null === $this->currentCommand || ! $this->currentCommand instanceof Message) {
             return $recordedEvents;
         }
 
@@ -83,7 +83,6 @@ final class TransactionManager implements Plugin, ActionEventListenerAggregate
         foreach ($recordedEvents as $recordedEvent) {
             $recordedEvent = $recordedEvent->withAddedMetadata('causation_id', $causationId);
             $recordedEvent = $recordedEvent->withAddedMetadata('causation_name', $causationName);
-
             $enrichedRecordedEvents[] = $recordedEvent;
         }
 

--- a/src/TransactionManager.php
+++ b/src/TransactionManager.php
@@ -7,6 +7,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
+
 namespace Prooph\EventStoreBusBridge;
 
 use Iterator;

--- a/src/TransactionManager.php
+++ b/src/TransactionManager.php
@@ -1,12 +1,11 @@
 <?php
-/*
- * This file is part of prooph/event-store-bus-bridge.
- * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2015-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * Date: 4/4/15 - 12:25 AM
  */
 namespace Prooph\EventStoreBusBridge;
 

--- a/tests/Container/EventPublisherFactoryTest.php
+++ b/tests/Container/EventPublisherFactoryTest.php
@@ -27,7 +27,7 @@ final class EventPublisherFactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_creates_an_event_publisher_using_the_default_service_name_for_getting_an_event_bus()
+    public function it_creates_an_event_publisher_using_the_default_service_name_for_getting_an_event_bus(): void
     {
         $eventBus = $this->prophesize(EventBus::class);
 

--- a/tests/Container/EventPublisherFactoryTest.php
+++ b/tests/Container/EventPublisherFactoryTest.php
@@ -1,12 +1,11 @@
 <?php
-/*
- * This file is part of the prooph/event-store-bus-bridge.
- * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2015-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * Date: 8/30/15 - 6:20 PM
  */
 namespace ProophTest\EventStoreBusBridge\Container;
 

--- a/tests/Container/EventPublisherFactoryTest.php
+++ b/tests/Container/EventPublisherFactoryTest.php
@@ -7,6 +7,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
+
 namespace ProophTest\EventStoreBusBridge\Container;
 
 use Interop\Container\ContainerInterface;

--- a/tests/Container/TransactionManagerFactoryTest.php
+++ b/tests/Container/TransactionManagerFactoryTest.php
@@ -28,7 +28,7 @@ final class TransactionManagerFactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_creates_a_transaction_manager()
+    public function it_creates_a_transaction_manager(): void
     {
         $commandBus = $this->prophesize(CommandBus::class);
 

--- a/tests/Container/TransactionManagerFactoryTest.php
+++ b/tests/Container/TransactionManagerFactoryTest.php
@@ -1,12 +1,11 @@
 <?php
-/*
- * This file is part of the prooph/event-store-bus-bridge.
- * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2015-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * Date: 8/30/15 - 2:16 PM
  */
 namespace ProophTest\EventStoreBusBridge\Container;
 

--- a/tests/Container/TransactionManagerFactoryTest.php
+++ b/tests/Container/TransactionManagerFactoryTest.php
@@ -7,6 +7,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
+
 namespace ProophTest\EventStoreBusBridge\Container;
 
 use Interop\Container\ContainerInterface;

--- a/tests/EventPublisherTest.php
+++ b/tests/EventPublisherTest.php
@@ -14,6 +14,7 @@ namespace ProophTest\EventStoreBusBridge;
 
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\ActionEventEmitter;
+use Prooph\Common\Event\DefaultListenerHandler;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStoreBusBridge\EventPublisher;
@@ -47,8 +48,9 @@ final class EventPublisherTest extends \PHPUnit_Framework_TestCase
         $commitPostListener = null;
 
         $actionEventEmitter->attachListener('commit.post', Argument::any())->will(
-            function ($args) use (&$commitPostListener) {
+            $function = function ($args) use (&$commitPostListener, &$function) {
                 $commitPostListener = $args[1];
+                return new DefaultListenerHandler($function);
             }
         );
 

--- a/tests/EventPublisherTest.php
+++ b/tests/EventPublisherTest.php
@@ -1,12 +1,11 @@
 <?php
-/*
- * This file is part of the prooph/event-store-bus-bridge.
- * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2015-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * Date: 8/30/15 - 6:06 PM
  */
 namespace ProophTest\EventStoreBusBridge;
 

--- a/tests/EventPublisherTest.php
+++ b/tests/EventPublisherTest.php
@@ -60,7 +60,7 @@ final class EventPublisherTest extends \PHPUnit_Framework_TestCase
 
         $commitPostEvent = $this->prophesize(ActionEvent::class);
 
-        $commitPostEvent->getParam('recordedEvents', [])->willReturn([$event1->reveal(), $event2->reveal()]);
+        $commitPostEvent->getParam('recordedEvents', new \ArrayIterator())->willReturn([$event1->reveal(), $event2->reveal()]);
 
         $eventPublisher->onEventStoreCommitPost($commitPostEvent->reveal());
     }

--- a/tests/EventPublisherTest.php
+++ b/tests/EventPublisherTest.php
@@ -30,7 +30,7 @@ final class EventPublisherTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_publishes_all_recorded_events()
+    public function it_publishes_all_recorded_events(): void
     {
         $event1 = $this->prophesize(Message::class);
         $event2 = $this->prophesize(Message::class);

--- a/tests/EventPublisherTest.php
+++ b/tests/EventPublisherTest.php
@@ -7,6 +7,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
+
 namespace ProophTest\EventStoreBusBridge;
 
 use Prooph\Common\Event\ActionEvent;

--- a/tests/EventPublisherTest.php
+++ b/tests/EventPublisherTest.php
@@ -14,6 +14,8 @@ namespace ProophTest\EventStoreBusBridge;
 
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\ActionEventEmitter;
+use Prooph\Common\Event\DefaultListenerHandler;
+use Prooph\Common\Event\ListenerHandler;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStoreBusBridge\EventPublisher;
@@ -47,8 +49,9 @@ final class EventPublisherTest extends \PHPUnit_Framework_TestCase
         $commitPostListener = null;
 
         $actionEventEmitter->attachListener('commit.post', Argument::any())->will(
-            function ($args) use (&$commitPostListener): void {
+            $function = function ($args) use (&$commitPostListener, &$function): ListenerHandler {
                 $commitPostListener = $args[1];
+                return new DefaultListenerHandler($function);
             }
         );
 

--- a/tests/EventPublisherTest.php
+++ b/tests/EventPublisherTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStoreBusBridge;
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\ActionEventEmitter;
 use Prooph\Common\Event\DefaultListenerHandler;
+use Prooph\Common\Event\ListenerHandler;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStoreBusBridge\EventPublisher;
@@ -48,7 +49,7 @@ final class EventPublisherTest extends \PHPUnit_Framework_TestCase
         $commitPostListener = null;
 
         $actionEventEmitter->attachListener('commit.post', Argument::any())->will(
-            $function = function ($args) use (&$commitPostListener, &$function) {
+            $function = function ($args) use (&$commitPostListener, &$function): ListenerHandler {
                 $commitPostListener = $args[1];
                 return new DefaultListenerHandler($function);
             }

--- a/tests/EventPublisherTest.php
+++ b/tests/EventPublisherTest.php
@@ -14,8 +14,6 @@ namespace ProophTest\EventStoreBusBridge;
 
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\ActionEventEmitter;
-use Prooph\Common\Event\DefaultListenerHandler;
-use Prooph\Common\Event\ListenerHandler;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStoreBusBridge\EventPublisher;
@@ -49,9 +47,8 @@ final class EventPublisherTest extends \PHPUnit_Framework_TestCase
         $commitPostListener = null;
 
         $actionEventEmitter->attachListener('commit.post', Argument::any())->will(
-            $function = function ($args) use (&$commitPostListener, &$function): ListenerHandler {
+            function ($args) use (&$commitPostListener): void {
                 $commitPostListener = $args[1];
-                return new DefaultListenerHandler($function);
             }
         );
 

--- a/tests/TransactionManagerTest.php
+++ b/tests/TransactionManagerTest.php
@@ -47,13 +47,13 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
         $appendToStreamListener = null;
 
         $emitter->attachListener('create.pre', Argument::any(), -1000)->will(
-            $function = function ($args) use (&$createStreamListener, &$function) {
+            $function = function ($args) use (&$createStreamListener, &$function): ListenerHandler {
                 $createStreamListener = $args[1];
                 return new DefaultListenerHandler($function);
             }
         );
         $emitter->attachListener('appendTo.pre', Argument::any(), -1000)->will(
-            $function = function ($args) use (&$appendToStreamListener, &$function) {
+            $function = function ($args) use (&$appendToStreamListener, &$function): ListenerHandler {
                 $appendToStreamListener = $args[1];
                 return new DefaultListenerHandler($function);
             }

--- a/tests/TransactionManagerTest.php
+++ b/tests/TransactionManagerTest.php
@@ -23,7 +23,8 @@ use Prooph\EventStore\Stream\StreamName;
 use Prooph\EventStoreBusBridge\TransactionManager;
 use Prooph\ServiceBus\CommandBus;
 use Prophecy\Argument;
-use Rhumsaa\Uuid\Uuid;
+use Prophecy\Prophecy\ObjectProphecy;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Class TransactionManagerTest
@@ -35,7 +36,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_attaches_itself_to_event_store_events()
+    public function it_attaches_itself_to_event_store_events(): void
     {
         $eventStoreMock = $this->prophesize(EventStore::class);
 
@@ -68,7 +69,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_attaches_itself_to_command_bus_initialize_and_finalize_events()
+    public function it_attaches_itself_to_command_bus_initialize_and_finalize_events(): void
     {
         $transactionManager = new TransactionManager();
 
@@ -85,7 +86,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_begins_a_transaction_on_command_dispatch_initialize()
+    public function it_begins_a_transaction_on_command_dispatch_initialize(): void
     {
         $eventStoreMock = $this->getEventStoreObjectProphecy();
 
@@ -105,7 +106,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_commits_a_transaction_on_command_dispatch_finalize_if_no_exception_was_thrown()
+    public function it_commits_a_transaction_on_command_dispatch_finalize_if_no_exception_was_thrown(): void
     {
         $eventStoreMock = $this->getEventStoreObjectProphecy();
 
@@ -127,7 +128,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_rollback_a_transaction_on_command_dispatch_finalize_if_exception_was_thrown()
+    public function it_rollback_a_transaction_on_command_dispatch_finalize_if_exception_was_thrown(): void
     {
         $eventStoreMock = $this->getEventStoreObjectProphecy();
 
@@ -151,7 +152,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_does_not_perform_rollback_after_transaction_commit()
+    public function it_does_not_perform_rollback_after_transaction_commit(): void
     {
         $eventStoreMock = $this->getEventStoreObjectProphecy();
 
@@ -175,7 +176,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_adds_causation_id_and_causation_name_on_event_store_create_stream()
+    public function it_adds_causation_id_and_causation_name_on_event_store_create_stream(): void
     {
         //Step 1: Track the command which will cause events
         $command = $this->prophesize(Message::class);
@@ -233,7 +234,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_adds_causation_id_and_causation_name_on_event_store_append_to_stream()
+    public function it_adds_causation_id_and_causation_name_on_event_store_append_to_stream(): void
     {
         //Step 1: Track the command which will cause events
         $command = $this->prophesize(Message::class);
@@ -289,7 +290,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_returns_early_on_event_store_create_stream_if_event_has_no_stream()
+    public function it_returns_early_on_event_store_create_stream_if_event_has_no_stream(): void
     {
         $createStreamActionEvent = $this->prophesize(ActionEvent::class);
 
@@ -307,7 +308,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_returns_early_if_command_was_null_when_handling_events()
+    public function it_returns_early_if_command_was_null_when_handling_events(): void
     {
         //Step 1: Create null command
         $command = null;
@@ -340,10 +341,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($stream, $createStreamActionEvent->getParam('stream'));
     }
 
-    /**
-     * @return \Prophecy\Prophecy\ObjectProphecy
-     */
-    private function getEventStoreObjectProphecy()
+    private function getEventStoreObjectProphecy(): ObjectProphecy
     {
         $actionEventEmitter = $this->prophesize(ActionEventEmitter::class);
 

--- a/tests/TransactionManagerTest.php
+++ b/tests/TransactionManagerTest.php
@@ -1,12 +1,11 @@
 <?php
-/*
- * This file is part of the prooph/event-store-bus-bridge.
- * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2015-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * Date: 8/30/15 - 12:25 PM
  */
 namespace ProophTest\EventStoreBusBridge;
 

--- a/tests/TransactionManagerTest.php
+++ b/tests/TransactionManagerTest.php
@@ -7,6 +7,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
+
 namespace ProophTest\EventStoreBusBridge;
 
 use Prooph\Common\Event\ActionEvent;

--- a/tests/TransactionManagerTest.php
+++ b/tests/TransactionManagerTest.php
@@ -15,7 +15,6 @@ namespace ProophTest\EventStoreBusBridge;
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\ActionEventEmitter;
 use Prooph\Common\Event\DefaultActionEvent;
-use Prooph\Common\Event\DefaultListenerHandler;
 use Prooph\Common\Event\ListenerHandler;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
@@ -47,15 +46,13 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
         $appendToStreamListener = null;
 
         $emitter->attachListener('create.pre', Argument::any(), -1000)->will(
-            $function = function ($args) use (&$createStreamListener, &$function): ListenerHandler {
+            function ($args) use (&$createStreamListener): void {
                 $createStreamListener = $args[1];
-                return new DefaultListenerHandler($function);
             }
         );
         $emitter->attachListener('appendTo.pre', Argument::any(), -1000)->will(
-            $function = function ($args) use (&$appendToStreamListener, &$function): ListenerHandler {
+            function ($args) use (&$appendToStreamListener): void {
                 $appendToStreamListener = $args[1];
-                return new DefaultListenerHandler($function);
             }
         );
 

--- a/tests/TransactionManagerTest.php
+++ b/tests/TransactionManagerTest.php
@@ -230,7 +230,7 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotNull($enrichedStream);
         $this->assertEquals('event_stream', $enrichedStream->streamName()->toString());
-        $this->assertEquals(1, count($enrichedStream->streamEvents()));
+        $this->assertCount(1, $enrichedStream->streamEvents());
         $this->assertSame($recordedEventCopy2->reveal(), $enrichedStream->streamEvents()[0]);
     }
 
@@ -349,7 +349,9 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
         $listenerHandler = $this->prophesize(ListenerHandler::class);
 
         $actionEventEmitter = $this->prophesize(ActionEventEmitter::class);
-        $actionEventEmitter->attachListener(Argument::any(), Argument::any(), Argument::any())->willReturn($listenerHandler->reveal());
+        $actionEventEmitter
+            ->attachListener(Argument::any(), Argument::any(), Argument::any())
+            ->willReturn($listenerHandler->reveal());
 
         $eventStoreMock = $this->prophesize(EventStore::class);
 

--- a/tests/TransactionManagerTest.php
+++ b/tests/TransactionManagerTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStoreBusBridge;
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\ActionEventEmitter;
 use Prooph\Common\Event\DefaultActionEvent;
+use Prooph\Common\Event\DefaultListenerHandler;
 use Prooph\Common\Event\ListenerHandler;
 use Prooph\Common\Messaging\Message;
 use Prooph\EventStore\EventStore;
@@ -46,13 +47,15 @@ final class TransactionManagerTest extends \PHPUnit_Framework_TestCase
         $appendToStreamListener = null;
 
         $emitter->attachListener('create.pre', Argument::any(), -1000)->will(
-            function ($args) use (&$createStreamListener): void {
+            $function = function ($args) use (&$createStreamListener, &$function): ListenerHandler {
                 $createStreamListener = $args[1];
+                return new DefaultListenerHandler($function);
             }
         );
         $emitter->attachListener('appendTo.pre', Argument::any(), -1000)->will(
-            function ($args) use (&$appendToStreamListener): void {
+            $function = function ($args) use (&$appendToStreamListener, &$function): ListenerHandler {
                 $appendToStreamListener = $args[1];
+                return new DefaultListenerHandler($function);
             }
         );
 


### PR DESCRIPTION
- add support for PHP 7.1
- uses custom prophecy branch (see https://github.com/phpspec/prophecy/pull/287)
- uses custom prooph/common branch ("prooph/common" : "dev-php_7_1 as 4.0")
- uses custom prooph/service-bus branch ("prooph/service-bus" : "dev-php_7_1 as 6.0")
- uses custom prooph/event-store branch ("prooph/common" : "dev-php_7_1 as 7.0")
- update copyright in php files
- add docheader
- allow multiple event stores to be configured