### PR TITLE
CausationMetadataEnricher must only be added to the event store when …

### DIFF
--- a/docs/causation_metadata_enricher.md
+++ b/docs/causation_metadata_enricher.md
@@ -22,4 +22,4 @@ That's it!
 If you are using the `container-aware factories` shipped with prooph/event-store and prooph/service-bus you may also
 want to auto register the `CausationMetadataEnricher`.
 
-Add the `CausationMetadataEnricher` as plugin to the command bus as well as the event-store. Use the `CausationMetadataEnricherFactory`. 
+Add the `CausationMetadataEnricher` as plugin to the event-store. Use the `CausationMetadataEnricherFactory`. 


### PR DESCRIPTION
…using the CausationMetadataEnricherFactory