### PR TITLE
Dispatch EVENT_APPEND_TO and EVENT_CREATE in transactional event store when not inside transaction

### DIFF
--- a/src/EventPublisher.php
+++ b/src/EventPublisher.php
@@ -43,7 +43,7 @@ final class EventPublisher extends AbstractPlugin
             function (ActionEvent $event) use ($eventStore): void {
                 $recordedEvents = $event->getParam('streamEvents', new \ArrayIterator());
 
-                if (!$this->inTransaction($eventStore)) {
+                if (! $this->inTransaction($eventStore)) {
                     if ($event->getParam('streamNotFound', false)
                         || $event->getParam('concurrencyException', false)
                     ) {
@@ -65,7 +65,7 @@ final class EventPublisher extends AbstractPlugin
                 $stream = $event->getParam('stream');
                 $recordedEvents = $stream->streamEvents();
 
-                if (!$this->inTransaction($eventStore)) {
+                if (! $this->inTransaction($eventStore)) {
                     if ($event->getParam('streamExistsAlready', false)) {
                         return;
                     }

--- a/tests/EventPublisherTest.php
+++ b/tests/EventPublisherTest.php
@@ -26,7 +26,6 @@ use Prooph\EventStore\StreamName;
 use Prooph\EventStore\TransactionalActionEventEmitterEventStore;
 use Prooph\EventStoreBusBridge\EventPublisher;
 use Prooph\ServiceBus\EventBus;
-use Prophecy\Prophecy\ObjectProphecy;
 
 class EventPublisherTest extends TestCase
 {


### PR DESCRIPTION
In some situations, a transactional event store might be used without a transaction manager or any transaction at all. However, with current implementation, is only possible to publish events from a transactional event store when a transaction is commited.

I think that behaviour would be more accurate if event publisher not only checks if the event store is transactional but if it's wrapped in a transaction in order to publish or cache them until transaction commit/rollback.

